### PR TITLE
Fix Flakiness in FamilyTest

### DIFF
--- a/src/test/java/co/streamx/fluent/JPA/repository/entities/Child.java
+++ b/src/test/java/co/streamx/fluent/JPA/repository/entities/Child.java
@@ -39,8 +39,8 @@ public class Child {
     private int index;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
-    @JoinColumns({ @JoinColumn(name = "code", insertable = false, updatable = false),
-            @JoinColumn(name = "id", insertable = false, updatable = false) })
+    @JoinColumns({ @JoinColumn(name = "code", insertable = false, updatable = false, referencedColumnName="\"co de\""),
+            @JoinColumn(name = "id", insertable = false, updatable = false, referencedColumnName="id") })
     private Parent parent;
 
     @SuppressWarnings("serial")


### PR DESCRIPTION
`FamilyTest#test1` is not guaranteed to pass every time. This is because `ParentRepository#getParentChildren` does a join with the parent and child tables. Normally, it will look like `SELECT t1.* FROM Parent AS t0 INNER JOIN Child AS t1 ON (t0."co de" = t1.code AND to.id = t1.id)` which would pass. However, this join is not guaranteed and sometimes wlil turn into `SELECT t1.* FROM Parent AS t0 INNER JOIN Child AS t1 ON (t0.id = t1.code AND to."co de" = t1.id)`.

This change specifies which columns in the child table should be joined with which column in the parent table.